### PR TITLE
fix: `LIMIT_GIVE_COUNT_OF_SPECIAL_EMOJI` default 값 변경

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -12,7 +12,7 @@ BOT_NAME="heymojiBOT"
 ERROR_CHANNEL=""
 
 SPECIAL_EMOJI="trophy" # 🏆
-LIMIT_GIVE_COUNT_OF_SPECIAL_EMOJI=5
+LIMIT_GIVE_COUNT_OF_SPECIAL_EMOJI=1000
 ALLOWED_REACTION_LIST=["pray", "heart", "eye_shaking", "+1", "기도", "기쁨", "kkkk", "trophy", "트로피"]
 ALLOWED_EMOJI_TYPES='[
     {"emoji": "❤️", "emoji_names": ["heart"]},

--- a/README.md
+++ b/README.md
@@ -75,24 +75,24 @@ DDD에 대한 스터디를 위해 구조를 변경했으며 https://github.com/E
 DB는 `MySQL`을 사용하며 비동기 처리를 위해 `aiomysql`라이브러리를 함께 사용합니다.<br/>
 다른 DB 사용하려면 `config` 설정이 조금 달라질 수 있습니다.
 
-| 이름                                | 설명                                  |
-|-----------------------------------|-------------------------------------|
-| ENV                               | 배포환경 정의                             |
-| ALLOW_ORIGINS                     | CORS를 허용할 ORIGIN 리스트                |
-| DB_HOST                           | DB 호스트                              |
-| DB_PORT                           | DB 포트                               |
-| DATABASE                          | DB 이름                               |
-| DB_USERNAME                       | DB 접속 유저네임                          |
-| DB_PASSWORD                       | DB 패스워드                             |
-| SLACK_TOKEN                       | 슬랙 토큰                               |
-| BOT_NAME                          | 슬랙봇 이름                              |
-| ERROR_CHANNEL                     | 슬랙 에러 리포팅 채널                        |
-| SPECIAL_EMOJI                     | 특별한 의미를 가진 이모지                      |
-| LIMIT_GIVE_COUNT_OF_SPECIAL_EMOJI | 하루에 남길수 있는 SPECIAL_EMOJI 최대 개수      |
-| ALLOWED_REACTION_LIST             | 웹훅 리액션으로 허용된 이모지(reaction)들을 정의합니다. |
-| ALLOWED_EMOJI_TYPES               | 핸들링할 이모지들을 정의합니다.                   |
-| RANK_URL                          | 랭킹 웹페이지 URK                         |
-| DEFAULT_AVATAR_URL                | 기본 프로필 이미지 URL                      |
+| 이름                                | 설명                                    |
+|-----------------------------------|---------------------------------------|
+| ENV                               | 배포환경 정의                               |
+| ALLOW_ORIGINS                     | CORS를 허용할 ORIGIN 리스트                  |
+| DB_HOST                           | DB 호스트                                |
+| DB_PORT                           | DB 포트                                 |
+| DATABASE                          | DB 이름                                 |
+| DB_USERNAME                       | DB 접속 유저네임                            |
+| DB_PASSWORD                       | DB 패스워드                               |
+| SLACK_TOKEN                       | 슬랙 토큰                                 |
+| BOT_NAME                          | 슬랙봇 이름                                |
+| ERROR_CHANNEL                     | 슬랙 에러 리포팅 채널                          |
+| SPECIAL_EMOJI                     | 특별한 의미를 가진 이모지                        |
+| LIMIT_GIVE_COUNT_OF_SPECIAL_EMOJI | 매월 다른 멤버에게 줄 수 있는 SPECIAL_EMOJI 제한 개수 |
+| ALLOWED_REACTION_LIST             | 웹훅 리액션으로 허용된 이모지(reaction)들을 정의합니다.   |
+| ALLOWED_EMOJI_TYPES               | 핸들링할 이모지들을 정의합니다.                     |
+| RANK_URL                          | 랭킹 웹페이지 URK                           |
+| DEFAULT_AVATAR_URL                | 기본 프로필 이미지 URL                        |
 
 <br/>
 
@@ -172,6 +172,7 @@ uvicorn app.main:app --port 8080
 🙉 유저 보이기
 @EmojiBot --show_user --slack_id=슬랙ID
 ```
+
 ### 🎖 show_best_member 예시
 
 <img width="499" alt="show_best_member 예시" src="https://user-images.githubusercontent.com/24591259/222969485-290c6d9d-841c-4a01-bd77-12af62db63da.png">
@@ -199,6 +200,7 @@ if [ "$checker" == "0" ]; then
 	cd $SCRIPT_PATH && `uvicorn main:app --port 8080 &`
 fi
 ```
+
 <br/>
 
 # 🤖 Slack Bot 설정

--- a/app/domains/reactions/services.py
+++ b/app/domains/reactions/services.py
@@ -158,6 +158,11 @@ class ReactionService(GenericService):
 
     @classmethod
     async def _can_increase_special_emoji(cls, reaction: Reaction) -> bool:
+        """
+        todo: 리팩토링 하면서 일별 카운트 로직을 제거 했음. 현재 로직에서 `LIMIT_GIVE_COUNT_OF_SPECIAL_EMOJI`는
+            매월 이모지를 줄 수 있는 카운트 제한이라고 보면됨.
+            현재는 굳이 매일 줄 수 있는 이모지 제한이 의미없을 것 같아서 유지하는 방향으로 정리
+        """
         count = await cls._repository().count_special_emoji_by_date_and_from_user(
             from_user_id=reaction.from_user_id,
             year=reaction.year,

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -26,7 +26,7 @@ class BaseConfig(BaseSettings):
     BOT_NAME: str = Field(env="BOT_NAME", default="heymojiBOT")
 
     SPECIAL_EMOJI: Optional[str] = Field(env="SPECIAL_EMOJI", default="trophy")
-    LIMIT_GIVE_COUNT_OF_SPECIAL_EMOJI: int = Field(env="LIMIT_GIVE_COUNT_OF_SPECIAL_EMOJI", default=5)
+    LIMIT_GIVE_COUNT_OF_SPECIAL_EMOJI: int = Field(env="LIMIT_GIVE_COUNT_OF_SPECIAL_EMOJI", default=1000)
     ALLOWED_REACTION_LIST: list = Field(
         env="ALLOWED_REACTION_LIST",
         default=["pray", "heart", "eye_shaking", "+1", "기도", "기쁨", "kkkk", "trophy", "트로피"]


### PR DESCRIPTION
## 작업 내용 :mag:
- LIMIT_GIVE_COUNT_OF_SPECIAL_EMOJI 가 현재 월별제한으로 로직이 되어있는데 설명은 일별로 되어있음
- 이전 리팩토링시 일별카운트 제한 로직을 제거하면서 이후 작업에서 잘못 로직이 수정되었음

## 변경 사항 :hammer_and_wrench:
- LIMIT_GIVE_COUNT_OF_SPECIAL_EMOJI 디폴트 값 변경

## 리뷰 노트 :memo:

## 스크린샷 :camera:
